### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/damidojo/c165619f-929c-4e19-83da-a0e66ba4e923/a7ade24a-e434-4869-8e1c-fb3171c917ab/_apis/work/boardbadge/bcf8945a-0629-4a79-a066-ac6bb3e0961a)](https://dev.azure.com/damidojo/c165619f-929c-4e19-83da-a0e66ba4e923/_boards/board/t/a7ade24a-e434-4869-8e1c-fb3171c917ab/Microsoft.RequirementCategory)
 # A COFFEE ORDERING WEBSITE
 
 #OVERVIEW


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/damidojo/c165619f-929c-4e19-83da-a0e66ba4e923/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.